### PR TITLE
feat: playSfx 支持 playbackRate 音调调节

### DIFF
--- a/packages/engine/src/audio.ts
+++ b/packages/engine/src/audio.ts
@@ -23,8 +23,15 @@ export interface AudioHandle {
   resume(): void;
   volume: number;
   loop: boolean;
+  /** Playback speed / pitch (default: 1.0, range: 0.5 ~ 2.0) */
+  playbackRate: number;
   readonly playing: boolean;
   destroy(): void;
+}
+
+export interface SfxOptions {
+  volume?: number;
+  playbackRate?: number;
 }
 
 export interface AudioAdapter {
@@ -69,6 +76,9 @@ class WebAudioHandle implements AudioHandle {
 
   get loop() { return this._el.loop; }
   set loop(v: boolean) { this._el.loop = v; }
+
+  get playbackRate() { return this._el.playbackRate; }
+  set playbackRate(v: number) { this._el.playbackRate = v; }
 
   get playing() { return this._playing && !this._el.paused; }
 
@@ -126,6 +136,9 @@ class MiniGameAudioHandle implements AudioHandle {
   get loop() { return this._ctx.loop; }
   set loop(v: boolean) { this._ctx.loop = v; }
 
+  get playbackRate() { return this._ctx.playbackRate ?? 1; }
+  set playbackRate(v: number) { this._ctx.playbackRate = v; }
+
   get playing() { return this._playing; }
 
   destroy() {
@@ -162,6 +175,7 @@ class MockAudioHandle implements AudioHandle {
   private _playing = false;
   volume = 1;
   loop = false;
+  playbackRate = 1;
   readonly src: string;
 
   constructor(src: string) { this.src = src; }
@@ -242,11 +256,15 @@ export class AudioManager {
 
   // ── SFX ──
 
-  /** Play a sound effect (can overlap) */
-  playSfx(name: string, volume?: number): void {
+  /** Play a sound effect (can overlap). Accepts volume number or options object. */
+  playSfx(name: string, opts?: number | SfxOptions): void {
     const base = this._sounds.get(name);
     if (!base) return;
     if (this._muted) return;
+
+    const { volume, playbackRate } = typeof opts === 'number'
+      ? { volume: opts, playbackRate: 1 }
+      : { volume: opts?.volume ?? 1, playbackRate: opts?.playbackRate ?? 1 };
 
     // Clean up finished SFX
     this._activeSfx = this._activeSfx.filter(h => h.playing);
@@ -259,7 +277,8 @@ export class AudioManager {
     }
 
     const handle = this._adapter.clone(base);
-    handle.volume = (volume ?? 1) * this._sfxVolume;
+    handle.volume = volume * this._sfxVolume;
+    handle.playbackRate = playbackRate;
     handle.loop = false;
     handle.play();
     this._activeSfx.push(handle);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -11,7 +11,7 @@ export { TtAdapter } from './platform/tt.js';
 export { loadImage, setAssetRoot, getAssetRoot, type ImageLike } from './image-loader.js';
 export { createOffscreenCanvas } from './canvas-utils.js';
 // Test utilities moved to '@lucid-2d/engine/testing' to avoid bundling @napi-rs/canvas in production
-export { AudioManager, createAudio, createMockAudio, type AudioManagerOptions, type AudioAdapter, type AudioHandle } from './audio.js';
+export { AudioManager, createAudio, createMockAudio, type AudioManagerOptions, type AudioAdapter, type AudioHandle, type SfxOptions } from './audio.js';
 export { Keyboard } from './keyboard.js';
 export { AssetLoader, type AssetEntry } from './asset-loader.js';
 export { batchSimulate, type SimulationConfig, type SimulationResult, type BatchResult } from './simulate.js';

--- a/packages/engine/tests/audio.test.ts
+++ b/packages/engine/tests/audio.test.ts
@@ -50,6 +50,26 @@ describe('AudioManager', () => {
     audio.playSfx('hit');
     audio.stopAllSfx(); // should not throw
   });
+
+  it('playSfx accepts options object with playbackRate', () => {
+    const audio = createMockAudio();
+    audio.load('click', 'assets/click.mp3');
+    // Should not throw with options object
+    audio.playSfx('click', { volume: 0.8, playbackRate: 1.5 });
+  });
+
+  it('playSfx backward-compatible with number volume', () => {
+    const audio = createMockAudio();
+    audio.load('click', 'assets/click.mp3');
+    // Old API: playSfx(name, volume)
+    audio.playSfx('click', 0.5);
+  });
+
+  it('playSfx accepts options with only playbackRate', () => {
+    const audio = createMockAudio();
+    audio.load('click', 'assets/click.mp3');
+    audio.playSfx('click', { playbackRate: 1.2 });
+  });
 });
 
 describe('BGM', () => {


### PR DESCRIPTION
## Summary

Closes #77

- `AudioHandle` 新增 `playbackRate` 属性（Web / MiniGame / Mock 三端）
- `playSfx(name, opts?)` 支持 options 对象：`{ volume?, playbackRate? }`
- 向后兼容：`playSfx('hit', 0.8)` 仍然有效

```typescript
// combo 音调递增
audio.playSfx('click', { playbackRate: 1.0 });   // 基准
audio.playSfx('click', { playbackRate: 1.06 });  // +半音
audio.playSfx('click', { playbackRate: 1.5 });   // +七度
```

## Test plan

- [x] 全量 1052 测试通过
- [x] options 对象 + playbackRate
- [x] 向后兼容 number volume
- [x] 只传 playbackRate 不传 volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)